### PR TITLE
10件登録されたら登録リンクをテキストに変更

### DIFF
--- a/app/views/speakers/_index.html.slim
+++ b/app/views/speakers/_index.html.slim
@@ -19,7 +19,11 @@ h2.font-bold.text-lg.mb-2
                   data: { turbo_method: :delete, turbo_frame: '_top' },
                   class: 'btn btn-xs btn-circle btn-ghost'
   = turbo_frame_tag 'new_speaker' do
-    .mt-3.px-1
-      = link_to '＋ 話す人を追加する',
-        new_roulette_speaker_path(@roulette),
-        class: 'text-neutral'
+    .mt-3.px-1 data-testid="new-speaker-link"
+      - if speakers.count < 10
+        = link_to '＋ 話す人を追加する',
+          new_roulette_speaker_path(@roulette),
+          class: 'text-neutral'
+      - else
+        p.text-neutral
+          | 話す人は10人以上追加できません

--- a/app/views/speakers/new.html.slim
+++ b/app/views/speakers/new.html.slim
@@ -1,5 +1,5 @@
 = turbo_frame_tag 'new_speaker'
-  div
+  .mt-3
     = form_with model: [@roulette, @speaker],
       html: { data: { turbo_frame: '_top' } },
       class: 'w-full flex' do |f|

--- a/app/views/talk_themes/_index.html.slim
+++ b/app/views/talk_themes/_index.html.slim
@@ -19,7 +19,11 @@ h2.font-bold.text-lg.mb-2
                   data: { turbo_method: :delete, turbo_frame: '_top' },
                   class: 'btn btn-xs btn-circle btn-ghost'
   = turbo_frame_tag 'new_talk_theme' do
-    .mt-3.px-1
-      = link_to '＋ トークテーマを追加する',
-        new_roulette_talk_theme_path(@roulette),
-        class: 'text-neutral'
+    .mt-3.px-1 data-testid="new-talk-theme-link"
+      - if talk_themes.count < 10
+        = link_to '＋ トークテーマを追加する',
+          new_roulette_talk_theme_path(@roulette),
+          class: 'text-neutral'
+      - else
+        p.text-neutral
+          | トークテーマは10個以上追加できません

--- a/spec/system/roulettes_spec.rb
+++ b/spec/system/roulettes_spec.rb
@@ -132,17 +132,18 @@ RSpec.describe 'Roulettes', type: :system do
     expect(find('.theme__labelContainer').all('li').count).to eq 3
   end
 
-  scenario 'user fails to register 11th talk theme', js: true do
-    FactoryBot.create_list(:talk_theme, 6, roulette: @roulette)
+  scenario 'it toggles a link to text when 10 themes are registered', js: true do
+    FactoryBot.create_list(:talk_theme, 5, roulette: @roulette)
     visit roulette_path(@roulette)
-    expect(find('#talk_themes_list').all('li').count).to eq 10
     expect do
       click_link 'トークテーマを追加する'
       fill_in 'talk_theme[theme]', with: 'トークテーマ テスト'
       click_button '登録'
-      expect(find('#talk_themes_list')).to_not have_content('トークテーマ テスト')
-    end.to change(@roulette.talk_themes, :count).by(0)
-    expect(find('#talk_themes_list').all('li').count).to eq 10
+      expect(find('#talk_themes_list')).to have_content('トークテーマ テスト')
+    end.to change(@roulette.talk_themes, :count).by(1)
+    new_link_element = find("[data-testid='new-talk-theme-link']")
+    expect(new_link_element).to have_content('トークテーマは10個以上追加できません')
+    expect(new_link_element).to_not have_selector('a')
   end
 
   scenario 'user add a speaker', js: true do
@@ -182,17 +183,18 @@ RSpec.describe 'Roulettes', type: :system do
     expect(find('.speaker__labelContainer').all('li').count).to eq 3
   end
 
-  scenario 'user fails to register 11th speaker', js: true do
-    FactoryBot.create_list(:speaker, 6, roulette: @roulette)
+  scenario 'it toggles a link to text when 10 speakers are registered', js: true do
+    FactoryBot.create_list(:speaker, 5, roulette: @roulette)
     visit roulette_path(@roulette)
-    expect(find('#speakers_list').all('li').count).to eq 10
     expect do
       click_link '話す人を追加する'
       fill_in 'speaker[name]', with: 'ユーザー テスト'
       click_button '登録'
-      expect(find('#speakers_list')).to_not have_content('ユーザー テスト')
-    end.to change(@roulette.speakers, :count).by(0)
-    expect(find('#speakers_list').all('li').count).to eq 10
+      expect(find('#speakers_list')).to have_content('ユーザー テスト')
+    end.to change(@roulette.speakers, :count).by(1)
+    new_link_element = find("[data-testid='new-speaker-link']")
+    expect(new_link_element).to have_content('話す人は10人以上追加できません')
+    expect(new_link_element).to_not have_selector('a')
   end
 
   scenario 'user registers a one-line talk theme', js: true do


### PR DESCRIPTION
- https://github.com/siso25/roulette-talk/issues/91

トークテーマと話す人がそれぞれ10件登録されたら、追加リンクをテキストに変更するよう修正