### PR TITLE
ルーレットの更新時にセッションストレージがリセットされないバグを修正

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: .ruby-version
           bundler-cache: true
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: .ruby-version
           bundler-cache: true
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/app/javascript/controllers/candidate_controller.js
+++ b/app/javascript/controllers/candidate_controller.js
@@ -2,11 +2,17 @@ import { Controller } from '@hotwired/stimulus'
 import { save } from '../helpers/storage'
 
 export default class extends Controller {
-  static targets = ['talkTheme', 'speakerName']
+  static outlets = ['roulette']
 
-  connect() {
-    save('talk', this.createLotteryString(this.talkThemeTargets.length))
-    save('speaker', this.createLotteryString(this.speakerNameTargets.length))
+  reset() {
+    save(
+      'talk',
+      this.createLotteryString(this.rouletteOutlet.talkThemeTargets.length)
+    )
+    save(
+      'speaker',
+      this.createLotteryString(this.rouletteOutlet.speakerNameTargets.length)
+    )
   }
 
   private

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import CandidateController from "./candidate_controller"
+application.register("candidate", CandidateController)
+
 import ClipboardController from "./clipboard_controller"
 application.register("clipboard", ClipboardController)
 

--- a/app/javascript/controllers/roulette_label_controller.js
+++ b/app/javascript/controllers/roulette_label_controller.js
@@ -21,7 +21,6 @@ export default class extends Controller {
 
   setLabelPosition() {
     const obj = this.switchByWidth()
-    console.log(obj)
     const angle = 360 / this.countValue
     const itemPositionAngle = angle / 2 + angle * this.indexValue
     const position = this.calcTopAndLeftPosition(

--- a/app/views/roulettes/_roulette.html.slim
+++ b/app/views/roulettes/_roulette.html.slim
@@ -1,4 +1,5 @@
-= turbo_frame_tag 'roulette'
+= turbo_frame_tag 'roulette',
+  'data-controller': 'roulette'
   div class="flex-initial w-[350px] md:w-[500px] lg:w-[600px]\
             h-[350px] md:h-[500px] lg:h-[600px]"
     div class="text-center relative w-[350px] md:w-[500px] lg:w-[600px]"

--- a/app/views/roulettes/show.html.slim
+++ b/app/views/roulettes/show.html.slim
@@ -36,7 +36,7 @@
                 data-rotate-target="speakerResult"]
               span
                 | さんです。
-        div data-controller="roulette"
+        div
           .flex
             = render partial: 'roulettes/roulette',
               locals: { talk_themes: @talk_themes, speakers: @speakers }
@@ -48,7 +48,9 @@
               | スタート
             button.btn.bg-neutral-content.mt-auto.tracking-wider.w-36.md:w-32[
               data-rotate-target="resetButton"
-              data-action="click->roulette#reset"]
+              data-controller="candidate"
+              data-candidate-roulette-outlet="#roulette"
+              data-action="click->candidate#reset"]
               | リセット
     .mx-auto.lg:w-96.lg:ml-24.px-6.lg:px-0
       .mt-10.lg:mt-28.lg:h-80

--- a/app/views/roulettes/show.html.slim
+++ b/app/views/roulettes/show.html.slim
@@ -26,18 +26,16 @@
                  bg-primary-content/[.85] p-3 md:p-6 w-11/12 invisible"
           data-rotate-target="resultText"]
           .text-xl.md:text-2xl.text-left.w-fit.mx-auto.tracking-wider
-            .flex
-              p
-                | トークテーマは
-                span.text-accent.font-bold.ml-3[
-                  data-rotate-target="talkThemeResult"]
-            .flex
-              p
-                | 話すのは
-                span.text-accent.font-bold.mx-3[
-                  data-rotate-target="speakerResult"]
-                span
-                  | さんです。
+            p
+              | トークテーマは
+              span.text-accent.font-bold.ml-3[
+                data-rotate-target="talkThemeResult"]
+            p
+              | 話すのは
+              span.text-accent.font-bold.mx-3[
+                data-rotate-target="speakerResult"]
+              span
+                | さんです。
         div data-controller="roulette"
           .flex
             = render partial: 'roulettes/roulette',


### PR DESCRIPTION
ルーレットの更新をTurbo Streamsに変更したことによって、roulette_controllerのconnectが発生しなくなった。
そのため、roulette_controllerを設定する範囲を変更し、リセットボタンように新しいコントローラーを追加した。