### PR TITLE
トークテーマと話す人の並び替えに登録日時を使うよう変更した

### DIFF
--- a/app/controllers/roulettes_controller.rb
+++ b/app/controllers/roulettes_controller.rb
@@ -3,8 +3,8 @@
 class RoulettesController < ApplicationController
   def show
     @roulette = Roulette.find(params[:id])
-    @talk_themes = @roulette.talk_themes.order(:id)
-    @speakers = @roulette.speakers.order(:id)
+    @talk_themes = @roulette.talk_themes.order(:created_at)
+    @speakers = @roulette.speakers.order(:created_at)
   end
 
   def create

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -9,8 +9,8 @@ class SpeakersController < ApplicationController
 
   def create
     @roulette.speakers.create(speaker_params)
-    @speakers = @roulette.speakers.order(:id)
-    @talk_themes = @roulette.talk_themes.order(:id)
+    @speakers = @roulette.speakers.order(:created_at)
+    @talk_themes = @roulette.talk_themes.order(:created_at)
   end
 
   def edit
@@ -19,14 +19,14 @@ class SpeakersController < ApplicationController
 
   def update
     @roulette.speakers.find(params[:id]).update(speaker_params)
-    @speakers = @roulette.speakers.order(:id)
-    @talk_themes = @roulette.talk_themes.order(:id)
+    @speakers = @roulette.speakers.order(:created_at)
+    @talk_themes = @roulette.talk_themes.order(:created_at)
   end
 
   def destroy
     @roulette.speakers.find(params[:id]).destroy
-    @speakers = @roulette.speakers.order(:id)
-    @talk_themes = @roulette.talk_themes.order(:id)
+    @speakers = @roulette.speakers.order(:created_at)
+    @talk_themes = @roulette.talk_themes.order(:created_at)
   end
 
   private

--- a/app/controllers/talk_themes_controller.rb
+++ b/app/controllers/talk_themes_controller.rb
@@ -9,8 +9,8 @@ class TalkThemesController < ApplicationController
 
   def create
     @roulette.talk_themes.create(talk_theme_params)
-    @talk_themes = @roulette.talk_themes.order(:id)
-    @speakers = @roulette.speakers.order(:id)
+    @talk_themes = @roulette.talk_themes.order(:created_at)
+    @speakers = @roulette.speakers.order(:created_at)
   end
 
   def edit
@@ -19,14 +19,14 @@ class TalkThemesController < ApplicationController
 
   def update
     @roulette.talk_themes.find(params[:id]).update(talk_theme_params)
-    @talk_themes = @roulette.talk_themes.order(:id)
-    @speakers = @roulette.speakers.order(:id)
+    @talk_themes = @roulette.talk_themes.order(:created_at)
+    @speakers = @roulette.speakers.order(:created_at)
   end
 
   def destroy
     @roulette.talk_themes.find(params[:id]).destroy
-    @talk_themes = @roulette.talk_themes.order(:id)
-    @speakers = @roulette.speakers.order(:id)
+    @talk_themes = @roulette.talk_themes.order(:created_at)
+    @speakers = @roulette.speakers.order(:created_at)
   end
 
   private

--- a/db/migrate/20240127091718_add_index_to_talk_themes_and_speakers.rb
+++ b/db/migrate/20240127091718_add_index_to_talk_themes_and_speakers.rb
@@ -1,0 +1,6 @@
+class AddIndexToTalkThemesAndSpeakers < ActiveRecord::Migration[7.0]
+  def change
+    add_index :talk_themes, :created_at
+    add_index :speakers, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_15_111733) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_27_091718) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,6 +24,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_15_111733) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_speakers_on_created_at"
     t.index ["roulette_id"], name: "index_speakers_on_roulette_id"
   end
 
@@ -32,6 +33,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_15_111733) do
     t.string "theme"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_talk_themes_on_created_at"
     t.index ["roulette_id"], name: "index_talk_themes_on_roulette_id"
   end
 


### PR DESCRIPTION
トークテーマと話す人の並び替えに使用するカラムをcreated_atに変更。
また、created_atを並び替えに使用するため当該カラムにindexを追加した。