### PR TITLE
iOSで結果を表示した際に不要な改行が入るバグ修正

### DIFF
--- a/app/javascript/controllers/rotate_controller.js
+++ b/app/javascript/controllers/rotate_controller.js
@@ -37,8 +37,8 @@ export default class extends Controller {
       () => {
         this.startButtonTarget.disabled = false
         this.resetButtonTarget.disabled = false
-        this.talkThemeResultTarget.innerText = findByKey('talkResult')
-        this.speakerResultTarget.innerText = findByKey('speakerResult')
+        this.talkThemeResultTarget.textContent = findByKey('talkResult')
+        this.speakerResultTarget.textContent = findByKey('speakerResult')
         this.resultTextTarget.style.visibility = 'visible'
         this.rouletteItemsOutlets.forEach((element) =>
           element.addStrikethrough()

--- a/app/views/roulettes/_roulettes_and_buttons.html.slim
+++ b/app/views/roulettes/_roulettes_and_buttons.html.slim
@@ -9,16 +9,15 @@
       .text-xl.md:text-2xl.text-left.w-fit.mx-auto.tracking-wider
         p
           | トークテーマは
-          span.text-accent.font-bold.ml-3[
+          span.text-accent.font-bold.ml-1.md:ml-3[
             data-rotate-target="talkThemeResult"]
         p
           | 話すのは
-          span.text-accent.font-bold.mx-3[
+          span.text-accent.font-bold.mx-1.md:mx-3[
             data-rotate-target="speakerResult"]
-          span
-            | さんです。
+          | さんです。
     div
-      .flex
+      .flex.justify-center
         = render partial: 'roulettes/roulette',
           locals: { talk_themes:, speakers: }
       .flex.justify-center.md:w-3/4.md:ml-auto.mt-8


### PR DESCRIPTION
- https://github.com/siso25/roulette-talk/issues/112

## 修正内容
ルーレット結果表示時にinnerTextを使用するとiOSでは末尾に改行が入るため、textContentを使用するように変更。