### PR TITLE
片方が0件のときの更新時に発生するエラーを修正

### DIFF
--- a/app/views/speakers/update.turbo_stream.slim
+++ b/app/views/speakers/update.turbo_stream.slim
@@ -2,6 +2,7 @@
   = render partial: 'speakers/index',
     locals: { roulette: @roulette, speakers: @speakers }
 
-= turbo_stream.replace 'roulette' do
-  = render partial: 'roulettes/roulette',
-    locals: { talk_themes: @talk_themes, speakers: @speakers }
+- if !@talk_themes.count.zero?
+  = turbo_stream.replace 'roulette' do
+    = render partial: 'roulettes/roulette',
+      locals: { talk_themes: @talk_themes, speakers: @speakers }

--- a/app/views/talk_themes/update.turbo_stream.slim
+++ b/app/views/talk_themes/update.turbo_stream.slim
@@ -2,6 +2,7 @@
   = render partial: 'talk_themes/index',
     locals: { roulette: @roulette, talk_themes: @talk_themes }
 
-= turbo_stream.replace 'roulette' do
-  = render partial: 'roulettes/roulette',
-    locals: { talk_themes: @talk_themes, speakers: @speakers }
+- if !@speakers.count.zero?
+  = turbo_stream.replace 'roulette' do
+    = render partial: 'roulettes/roulette',
+      locals: { talk_themes: @talk_themes, speakers: @speakers }

--- a/spec/system/speakers_spec.rb
+++ b/spec/system/speakers_spec.rb
@@ -69,6 +69,19 @@ RSpec.describe 'Speakers', type: :system do
     expect(find('.speaker__labelContainer')).to have_content('ユーザー 修正')
   end
 
+  scenario 'user modifies a speaker when no talk theme is registered', js: true do
+    roulette = Roulette.create
+    FactoryBot.create(:speaker, roulette:)
+    visit roulette_path(roulette)
+    within '#speakers_list' do
+      click_link 'ユーザー', match: :first
+      fill_in 'speaker[name]', with: 'ユーザー 修正'
+      click_button '更新'
+    end
+    expect(find('#speakers_list')).to have_content('ユーザー 修正')
+    expect(find('#no_items_roulette')).to have_content('トークテーマと話す人を1件以上登録してください。')
+  end
+
   scenario 'user deletes a speaker', js: true do
     visit roulette_path(@roulette)
     expect(JSON.parse(evaluate_script("sessionStorage.getItem('#{@roulette.id}')"))['speaker'].size).to eq 4

--- a/spec/system/talk_themes_spec.rb
+++ b/spec/system/talk_themes_spec.rb
@@ -69,6 +69,19 @@ RSpec.describe 'Talk Themes', type: :system do
     expect(find('.theme__labelContainer')).to have_content('トークテーマ 修正')
   end
 
+  scenario 'user modifies a talk theme when no speaker is registered', js: true do
+    roulette = Roulette.create
+    FactoryBot.create(:talk_theme, roulette:)
+    visit roulette_path(roulette)
+    within '#talk_themes_list' do
+      click_link 'トークテーマ', match: :first
+      fill_in 'talk_theme[theme]', with: 'トークテーマ 修正'
+      click_button '更新'
+    end
+    expect(find('#talk_themes_list')).to have_content('トークテーマ 修正')
+    expect(find('#no_items_roulette')).to have_content('トークテーマと話す人を1件以上登録してください。')
+  end
+
   scenario 'user deletes a talk theme', js: true do
     visit roulette_path(@roulette)
     talk_theme = find('#talk_themes_list').find('a', match: :first).text


### PR DESCRIPTION
## issue

- #148 

## 修正内容

トークテーマか話す人のどちらかが0件のときに、もう片方を更新すると、ルーレットが表示できずにテンプレートエラーが発生する。
そのため、上記の場合はルーレットを表示しないように修正。