### PR TITLE
本番環境でメモリが足りなくなっているため、512MBに変更

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -23,7 +23,7 @@ console_command = "/rails/bin/rails console"
 [[vm]]
   cpu_kind = "shared"
   cpus = 1
-  memory_mb = 256
+  memory_mb = 512
 
 [[statics]]
   guest_path = "/rails/public"


### PR DESCRIPTION
基本メモリの上限にはりついていて、out of memoryが数日続けて起こっている。